### PR TITLE
Rename `architecture` to `output` in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - split dataset creation and storage to zarr into separate functions `mllam_data_prep.create_dataset(...)` and `mllam_data_prep.create_dataset_zarr(...)` respectively ![\#7](https://github.com/mllam/mllam-data-prep/pull/7)
 
 - changes to spec from v0.1.0:
-    - `sampling_dim` removed from `architectures` section of spec, this is not needed to create the training data
-    - selection on variable coordinates values is now set with `inputs.{dataset_name}.variables.{variable_name}.values`
-      rather than `inputs.{dataset_name}.variables.{variable_name}.sel`
-    - when dimension-mapping method `stack_variables_by_var_name` is used the formatting string for the new variable
-      is now called `name_format` rather than `name`
-    - when dimension-mapping is done by simply renaming a dimension this configuration now needs to be set by providing
-      the named method (`rename`) explicitly through the `method` key, i.e. rather than `{to_dim}: {from_dim}` it is now
-      `{to_dim}: {method: rename, dim: {from_dim}}` to match the signature of the other dimension-mapping methods.
-    - coordinate value ranges for the dimensions that the architecture expects as input has been renamed from
-      `architecture.input_ranges` to `architecture.input_coord_ranges` to make the use more clear
-    - attribute `inputs.{dataset_name}.name` attribute has been removed, with the key `dataset_name` this is
-      superfluous
+  - the `architecture` section has been renamed `output` to make it clearer that this section defines the
+    properties of the output of `mllam-data-prep`
+  - `sampling_dim` removed from `output` (previously `architecture`) section of spec, this is not needed to create the training data
+  - the variables (and their dimensions) of the output definition has been renamed from `architecture.input_variables` to `output.variables`
+  - coordinate value ranges for the dimensions of the output (i.e. what that the architecture expects as input) has been renamed from
+    `architecture.input_ranges` to `output.coord_ranges` to make the use more clear
+  - selection on variable coordinates values is now set with `inputs.{dataset_name}.variables.{variable_name}.values`
+    rather than `inputs.{dataset_name}.variables.{variable_name}.sel`
+  - when dimension-mapping method `stack_variables_by_var_name` is used the formatting string for the new variable
+    is now called `name_format` rather than `name`
+  - when dimension-mapping is done by simply renaming a dimension this configuration now needs to be set by providing
+    the named method (`rename`) explicitly through the `method` key, i.e. rather than `{to_dim}: {from_dim}` it is now
+    `{to_dim}: {method: rename, dim: {from_dim}}` to match the signature of the other dimension-mapping methods.
+  - attribute `inputs.{dataset_name}.name` attribute has been removed, with the key `dataset_name` this is
+    superfluous
 
 ## [v0.1.0](https://github.com/mllam/mllam-data-prep/releases/tag/v0.1.0)
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ A full example configuration file is given in [example.danra.yaml](example.danra
 schema_version: v0.2.0
 dataset_version: v0.1.0
 
-architecture:
-  input_variables:
+output:
+  variables:
     static: [grid_index, static_feature]
     state: [time, grid_index, state_feature]
     forcing: [time, grid_index, forcing_feature]
-  input_coord_ranges:
+  coord_ranges:
     time:
       start: 1990-09-03T00:00
       end: 1990-09-09T00:00
@@ -101,7 +101,7 @@ inputs:
       grid_index:
         method: stack
         dims: [x, y]
-    target_architecture_variable: state
+    target_output_variable: state
 
   danra_surface:
     path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/single_levels.zarr
@@ -120,7 +120,7 @@ inputs:
       forcing_feature:
         method: stack_variables_by_var_name
         name_format: f"{var_name}"
-    target_architecture_variable: forcing
+    target_output_variable: forcing
 
   danra_lsm:
     path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/lsm.zarr
@@ -134,23 +134,24 @@ inputs:
       static_feature:
         method: stack_variables_by_var_name
         name_format: f"{var_name}"
-    target_architecture_variable: static
+    target_output_variable: static
+
 ```
 
-Apart from identifies to keep track of the configuration file format version and the datasets version, the configuration file is divided into two main sections:
+Apart from identifiers to keep track of the configuration file format version and the datasets version, the configuration file is divided into two main sections:
 
-- `architecture`: defines the input variables and dimensions of the model architecture to be trained. These are the variables and dimensions that the inputs datasets will be mapped to.
+- `output`: defines the input variables and dimensions of the output dataset produced by `mllam-data-prep`. These are the variables and dimensions that the inputs datasets will be mapped to. These should match the variables and dimensions expected by the model architecture you are training.
 - `inputs`: a list of source datasets to extract data from. These are the datasets that will be mapped to the architecture defined in the `architecture` section.
 
-### The `architecture` section
+### The `output` section
 
 ```yaml
-architecture:
-  input_variables:
+output:
+  variables:
     static: [grid_index, static_feature]
     state: [time, grid_index, state_feature]
     forcing: [time, grid_index, forcing_feature]
-  input_coord_ranges:
+  coord_ranges:
     time:
       start: 1990-09-03T00:00
       end: 1990-09-09T00:00
@@ -159,10 +160,10 @@ architecture:
     time: 1
 ```
 
-The `architecture` section defines three things:
+The `output` section defines three things:
 
-1. `input_variables`: what input variables the model architecture you are targeting expects, and what the dimensions are for each of these variables.
-2. `input_coord_ranges`: the range of values for each of the dimensions that the model architecture expects as input. These are optional, but allows you to ensure that the training dataset is created with the correct range of values for each dimension.
+1. `variables`: what input variables the model architecture you are targeting expects, and what the dimensions are for each of these variables.
+2. `coord_ranges`: the range of values for each of the dimensions that the model architecture expects as input. These are optional, but allows you to ensure that the training dataset is created with the correct range of values for each dimension.
 3. `chunking`: the chunk sizes to use when writing the training dataset to zarr. This is optional, but can be used to optimise the performance of the zarr dataset. By default the chunk sizes are set to the size of the dimension, but this can be overridden by setting the chunk size in the configuration file. A common choice is to set the dimension along which you are batching to align with the of each training item (e.g. if you are training a model with time-step roll-out of 10 timesteps, you might choose a chunksize of 10 along the time dimension).
 
 ### The `inputs` section

--- a/example.danra.yaml
+++ b/example.danra.yaml
@@ -1,18 +1,18 @@
 schema_version: v0.2.0
 dataset_version: v0.1.0
 
-architecture:
-  input_variables:
+output:
+  variables:
     static: [grid_index, static_feature]
     state: [time, grid_index, state_feature]
     forcing: [time, grid_index, forcing_feature]
-  input_coord_ranges:
+  coord_ranges:
     time:
       start: 1990-09-03T00:00
       end: 1990-09-09T00:00
       step: PT3H
   chunking:
-    time: 6
+    time: 1
 
 inputs:
   danra_height_levels:
@@ -38,7 +38,7 @@ inputs:
       grid_index:
         method: stack
         dims: [x, y]
-    target_architecture_variable: state
+    target_output_variable: state
 
   danra_surface:
     path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/single_levels.zarr
@@ -57,7 +57,7 @@ inputs:
       forcing_feature:
         method: stack_variables_by_var_name
         name_format: f"{var_name}"
-    target_architecture_variable: forcing
+    target_output_variable: forcing
 
   danra_lsm:
     path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/lsm.zarr
@@ -71,4 +71,4 @@ inputs:
       static_feature:
         method: stack_variables_by_var_name
         name_format: f"{var_name}"
-    target_architecture_variable: static
+    target_output_variable: static

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,10 +7,10 @@ INVALID_EXTRA_FIELDS_CONFIG_YAML = """
 schema_version: v0.1.0
 dataset_version: v0.1.0
 
-architecture:
-  input_variables:
+output:
+  variables:
     static: [grid_index, feature]
-  input_range:
+  coord_ranges:
     time:
       start: 1990-09-03T00:00
       end: 1990-09-04T00:00
@@ -39,12 +39,12 @@ VALID_EXAMPLE_CONFIG_YAML = """
 schema_version: v0.1.0
 dataset_version: v0.1.0
 
-architecture:
-  input_variables:
+output:
+  variables:
     static: [grid_index, feature]
     state: [time, grid_index, state_feature]
     forcing: [time, grid_index, forcing_feature]
-  input_range:
+  coord_ranges:
     time:
       start: 1990-09-03T00:00
       end: 1990-09-04T00:00
@@ -74,7 +74,7 @@ inputs:
       grid_index:
         method: flatten
         dims: [x, y]
-    target_architecture_variable: state
+    target_output_variable: state
 
   danra_surface:
     path: ~/Desktop/mldev/single_levels.zarr
@@ -91,7 +91,7 @@ inputs:
       forcing_feature:
         method: stack_variables_by_var_name
         name_format: f"{var_name}"
-    target_architecture_variable: forcing
+    target_output_variable: forcing
 """
 
 
@@ -101,6 +101,6 @@ def test_get_config_nested():
     for dataset_name, input_config in config.inputs.items():
         assert input_config.path is not None
         assert input_config.variables is not None
-        assert input_config.target_architecture_variable is not None
+        assert input_config.target_output_variable is not None
         with pytest.raises(AttributeError):
             input_config.foobarfield

--- a/tests/test_from_config.py
+++ b/tests/test_from_config.py
@@ -25,13 +25,13 @@ def test_merging_static_and_surface_analysis():
     config = dict(
         schema_version="v0.2.0",
         dataset_version="v0.1.0",
-        architecture=dict(
-            input_variables=dict(
+        output=dict(
+            variables=dict(
                 static=["grid_index", "static_feature"],
                 state=["time", "grid_index", "state_feature"],
                 forcing=["time", "grid_index", "forcing_feature"],
             ),
-            input_coord_ranges=dict(
+            coord_ranges=dict(
                 time=dict(
                     start=testdata.T_START.isoformat(),
                     end=testdata.T_END_ANALYSIS.isoformat(),
@@ -58,7 +58,7 @@ def test_merging_static_and_surface_analysis():
                         name_format="{var_name}",
                     ),
                 ),
-                target_architecture_variable="forcing",
+                target_output_variable="forcing",
             ),
             danra_static=dict(
                 path=datasets["static"],
@@ -74,7 +74,7 @@ def test_merging_static_and_surface_analysis():
                         name_format="{var_name}",
                     ),
                 ),
-                target_architecture_variable="static",
+                target_output_variable="static",
             ),
         ),
     )
@@ -118,13 +118,13 @@ def test_time_selection(source_data_contains_time_range, time_stepsize):
     config = dict(
         schema_version="v0.2.0",
         dataset_version="v0.1.0",
-        architecture=dict(
-            input_variables=dict(
+        output=dict(
+            variables=dict(
                 static=["grid_index", "feature"],
                 state=["time", "grid_index", "feature"],
                 forcing=["time", "grid_index", "feature"],
             ),
-            input_coord_ranges=dict(
+            coord_ranges=dict(
                 time=dict(
                     start=t_start_config.isoformat(),
                     end=t_end_config.isoformat(),
@@ -151,7 +151,7 @@ def test_time_selection(source_data_contains_time_range, time_stepsize):
                         name_format="{var_name}",
                     ),
                 ),
-                target_architecture_variable="forcing",
+                target_output_variable="forcing",
             ),
         ),
     )
@@ -176,8 +176,8 @@ def test_time_selection(source_data_contains_time_range, time_stepsize):
 @pytest.mark.parametrize("use_common_feature_var_name", [True, False])
 def test_feature_collision(use_common_feature_var_name):
     """
-    Use to arch target_architecture_variable variables which have a different number of features and
-    therefore need a unique feature dimension for each target_architecture_variable. This should raise
+    Use to arch target_output_variable variables which have a different number of features and
+    therefore need a unique feature dimension for each target_output_variable. This should raise
     a ValueError if the feature coordinates have the same name
     """
     tmpdir = tempfile.TemporaryDirectory()
@@ -194,8 +194,8 @@ def test_feature_collision(use_common_feature_var_name):
     config = dict(
         schema_version="v0.2.0",
         dataset_version="v0.1.0",
-        architecture=dict(
-            input_variables=dict(
+        output=dict(
+            variables=dict(
                 static=["grid_index", static_feature_var_name],
                 state=["time", "grid_index", state_feature_var_name],
             ),
@@ -219,7 +219,7 @@ def test_feature_collision(use_common_feature_var_name):
                         name_format="{var_name}",
                     ),
                 },
-                target_architecture_variable="state",
+                target_output_variable="state",
             ),
             danra_static=dict(
                 path=datasets["static"],
@@ -235,7 +235,7 @@ def test_feature_collision(use_common_feature_var_name):
                         name_format="{var_name}",
                     ),
                 },
-                target_architecture_variable="static",
+                target_output_variable="static",
             ),
         ),
     )


### PR DESCRIPTION
Rather than describing the output of `mllam-data-prep` through a section that details the properties of the model `architecture` to be trained the output of `mllam-data-prep` is now simply defined in `output` section of the config.