### PR TITLE
add missing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## vX.X.X
+
+### Changed
+
+- add missing `psutil` requirement. [\#21](https://github.com/mllam/mllam-data-prep/pull/21).
+
 ## [v0.3.0](https://github.com/mllam/mllam-data-prep/releases/tag/v0.3.0)
 
 [All changes](https://github.com/mllam/mllam-data-prep/compare/v0.3.0...v0.2.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "semver>=3.0.2",
     "rich>=13.7.1",
     "dask>=2024.2.1",
+    "psutil>=5.7.2",
 ]
 requires-python = ">=3.9"
 readme = "README.md"


### PR DESCRIPTION
fixes #19

Note, I propose here the `psutil` version requirement that is already set in `pdm.lock`.