### PR TITLE
Actually make dask.distributed optional #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- fix bug by making dependency `distributed` optional ![\#27](https://github.com/mllam/mllam-data-prep/pull/27)
 - fix typo in install dependency `distributed` ![\#20](https://github.com/mllam/mllam-data-prep/pull/20)
 - add missing `psutil` requirement. [\#21](https://github.com/mllam/mllam-data-prep/pull/21).
 

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -44,11 +44,11 @@ if __name__ == "__main__":
     if args.dask_distributed_local_core_fraction > 0.0:
         # Only run this block if dask.distributed is available
         if not DASK_DISTRIBUTED_AVAILABLE:
-            raise Exception(
+            raise ModuleNotFoundError(
                 "Currently dask.distributed isn't installed and therefore can't "
                 "be used in mllam-data-prep. Please install the optional dependency "
                 'with `python -m pip install "mllam-data-prep[dask-distributed]"`'
-        )
+            )
         
         # get the number of system cores
         n_system_cores = os.cpu_count()

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -12,7 +12,9 @@ try:
     from dask.diagnostics import ProgressBar
     from dask.distributed import LocalCluster
 except ImportError or ModuleNotFoundError:
-    logger.warning("psutil or dask.distributed not available. Skipping multiprocessing setup.")
+    logger.warning(
+        "psutil or dask.distributed not available. Skipping multiprocessing setup."
+    )
     dask_distributed_available = False
 
 if __name__ == "__main__":

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -11,7 +11,7 @@ try:
     import psutil
     from dask.diagnostics import ProgressBar
     from dask.distributed import LocalCluster
-except ModuleNotFoundError:
+except ImportError or ModuleNotFoundError:
     logger.warning("psutil or dask.distributed not available. Skipping multiprocessing setup.")
     dask_distributed_available = False
 

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -6,16 +6,13 @@ from loguru import logger
 from .create_dataset import create_dataset_zarr
 
 # Attempt to import psutil and dask.distributed modules
-dask_distributed_available = True
+DASK_DISTRIBUTED_AVAILABLE = True
 try:
     import psutil
     from dask.diagnostics import ProgressBar
     from dask.distributed import LocalCluster
 except ImportError or ModuleNotFoundError:
-    logger.warning(
-        "psutil or dask.distributed not available. Skipping multiprocessing setup."
-    )
-    dask_distributed_available = False
+    DASK_DISTRIBUTED_AVAILABLE = False
 
 if __name__ == "__main__":
     import argparse
@@ -44,8 +41,15 @@ if __name__ == "__main__":
     if args.show_progress:
         ProgressBar().register()
 
-    # Only run this block if dask.distributed is available
-    if dask_distributed_available and args.dask_distributed_local_core_fraction > 0.0:
+    if args.dask_distributed_local_core_fraction > 0.0:
+        # Only run this block if dask.distributed is available
+        if not DASK_DISTRIBUTED_AVAILABLE:
+            raise Exception(
+                "Currently dask.distributed isn't installed and therefore can't "
+                "be used in mllam-data-prep. Please install the optional dependency "
+                'with `python -m pip install "mllam-data-prep[dask-distributed]"`'
+            )
+        
         # get the number of system cores
         n_system_cores = os.cpu_count()
         # compute the number of cores to use

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -1,12 +1,19 @@
 import os
 from pathlib import Path
 
-import psutil
-from dask.diagnostics import ProgressBar
-from dask.distributed import LocalCluster
 from loguru import logger
 
 from .create_dataset import create_dataset_zarr
+
+# Attempt to import psutil and dask.distributed modules
+dask_distributed_available = True
+try:
+    import psutil
+    from dask.diagnostics import ProgressBar
+    from dask.distributed import LocalCluster
+except ModuleNotFoundError:
+    logger.warning("psutil or dask.distributed not available. Skipping multiprocessing setup.")
+    dask_distributed_available = False
 
 if __name__ == "__main__":
     import argparse
@@ -35,7 +42,8 @@ if __name__ == "__main__":
     if args.show_progress:
         ProgressBar().register()
 
-    if args.dask_distributed_local_core_fraction > 0.0:
+    # Only run this block if dask.distributed is available
+    if dask_distributed_available and args.dask_distributed_local_core_fraction > 0.0:
         # get the number of system cores
         n_system_cores = os.cpu_count()
         # compute the number of cores to use

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -49,7 +49,6 @@ if __name__ == "__main__":
                 "be used in mllam-data-prep. Please install the optional dependency "
                 'with `python -m pip install "mllam-data-prep[dask-distributed]"`'
             )
-        
         # get the number of system cores
         n_system_cores = os.cpu_count()
         # compute the number of cores to use

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                 "Currently dask.distributed isn't installed and therefore can't "
                 "be used in mllam-data-prep. Please install the optional dependency "
                 'with `python -m pip install "mllam-data-prep[dask-distributed]"`'
-            )
+        )
         
         # get the number of system cores
         n_system_cores = os.cpu_count()


### PR DESCRIPTION
- Added a check to make `psutil` and `dask.distributed` optional to improve flexibility.
- Introduced a flag (`dask_distributed_available`) to skip dask-related multiprocessing setup if dependencies are missing.
- Provided a warning message if `dask.distributed` or `psutil` are not available.
- Updated the code to run only dask-specific logic when the necessary modules are present.