### PR TITLE
Call validation split 'val' instead of 'validation' in example config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- change config example to call validation split `val` instead of `validation` [\#28](https://github.com/mllam/mllam-data-prep/pull/28)
 - fix typo in install dependency `distributed` ![\#20](https://github.com/mllam/mllam-data-prep/pull/20)
 - add missing `psutil` requirement. [\#21](https://github.com/mllam/mllam-data-prep/pull/21).
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ output:
         compute_statistics:
           ops: [mean, std, diff_mean, diff_std]
           dims: [grid_index, time]
-      validation:
+      val:
         start: 1990-09-06T00:00
         end: 1990-09-07T00:00
       test:
@@ -232,7 +232,7 @@ output:
         compute_statistics:
           ops: [mean, std, diff_mean, diff_std]
           dims: [grid_index, time]
-      validation:
+      val:
         start: 1990-09-06T00:00
         end: 1990-09-07T00:00
       test:

--- a/example.danra.yaml
+++ b/example.danra.yaml
@@ -22,7 +22,7 @@ output:
         compute_statistics:
           ops: [mean, std, diff_mean, diff_std]
           dims: [grid_index, time]
-      validation:
+      val:
         start: 1990-09-06T00:00
         end: 1990-09-07T00:00
       test:


### PR DESCRIPTION
The new datastores functionality in neural-lam https://github.com/mllam/neural-lam/pull/66 assumes that the validation split is called `val` rather than `validation`.

With this addition, the example config in `mllam-data-prep` uses `val` instead of `validation` to be consistent with that, as proposed in #24.