### PR TITLE
Remove global config for dataclass_wizard

### DIFF
--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -9,18 +9,6 @@ class InvalidConfigException(Exception):
     pass
 
 
-class GlobalJSONMeta(JSONWizard.Meta):
-    """
-    Global settings for the JSON load/dump process, that should apply to
-    *all* subclasses of `JSONWizard`.
-
-    Note: it does not matter where this class is defined, as long as it's
-    declared before any methods in `JSONWizard` are called.
-    """
-
-    raise_on_unknown_json_key = True
-
-
 @dataclass
 class Range:
     """
@@ -275,7 +263,7 @@ class Output:
 
 
 @dataclass
-class Config(dataclass_wizard.YAMLWizard):
+class Config(dataclass_wizard.JSONWizard, dataclass_wizard.YAMLWizard):
     """Configuration for the model.
 
     Attributes:
@@ -304,6 +292,9 @@ class Config(dataclass_wizard.YAMLWizard):
     inputs: Dict[str, InputDataset]
     schema_version: str
     dataset_version: str
+
+    class _(JSONWizard.Meta):
+        raise_on_unknown_json_key = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In working on the yaml configuration files in neural-lam I realised that setting global configuration for `dataclass_wizard` is a very bad idea. This should be obvious because different uses of `dataclass_wizard` might have different needs for configuration, however previously I didn't realise how to set the config when using `dataclass_wizard.YAMLWizard`. It turns out the key is to 1) also inherit from `dataclass_wizard.JSONWizard` (and make this the primary parent class) and 2) use `dataclass_wizard.JSONWizard.Meta` to define the config (not `dataclass_wizard.YAMLWizard.Meta` since this class does not exist).

This commit removes the global config for `dataclass_wizard` and only sets the configuration on `mllam-data-preps` `mllam_data_prep.config.Config` config dataclass.