### PR TITLE
Feature/add more statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode/
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m pip install mllam-data-prep[dask-distributed]
 
 ## Developing `mllam-data-prep`
 
-To work on developing `mllam-data-prep` it easiest to install and manage the dependencies with [pdm](https://pdm.fming.dev/). To get started clone your fork of [the main repo](https://github.com/mllam/mllam-data-prep) locally:
+To work on developing `mllam-data-prep` it is easiest to install and manage the dependencies with [pdm](https://pdm.fming.dev/). To get started clone your fork of [the main repo](https://github.com/mllam/mllam-data-prep) locally:
 
 ```bash
 git clone https://github.com/<your-github-username>/mllam-data-prep
@@ -41,7 +41,7 @@ pdm use --venv in-project
 pdm install
 ```
 
-All the linting is handelled by `pre-commit` which can be setup to automatically be run on each `git commit` by installing the git commit hook:
+All the linting is handled by `pre-commit` which can be setup to automatically be run on each `git commit` by installing the git commit hook:
 
 ```bash
 pdm run pre-commit install
@@ -244,7 +244,7 @@ The `output` section defines three things:
 
 1. `variables`: what input variables the model architecture you are targeting expects, and what the dimensions are for each of these variables.
 2. `coord_ranges`: the range of values for each of the dimensions that the model architecture expects as input. These are optional, but allows you to ensure that the training dataset is created with the correct range of values for each dimension.
-3. `chunking`: the chunk sizes to use when writing the training dataset to zarr. This is optional, but can be used to optimise the performance of the zarr dataset. By default the chunk sizes are set to the size of the dimension, but this can be overridden by setting the chunk size in the configuration file. A common choice is to set the dimension along which you are batching to align with the of each training item (e.g. if you are training a model with time-step roll-out of 10 timesteps, you might choose a chunksize of 10 along the time dimension).
+3. `chunking`: the chunk sizes to use when writing the training dataset to zarr. This is optional, but can be used to optimise the performance of the zarr dataset. By default the chunk sizes are set to the size of the dimension, but this can be overridden by setting the chunk size in the configuration file. A common choice is to set the dimension along which you are batching to align with that of each training item (e.g. if you are training a model with time-step roll-out of 10 timesteps, you might choose a chunksize of 10 along the time dimension).
 4. Splitting and calculation of statistics of the output variables, using the `splitting` section. The `output.splitting.splits` attribute defines the individual splits to create (for example `train`, `val` and `test`) and `output.splitting.dim` defines the dimension to split along. The `compute_statistics` can be optionally set for a given split to calculate the statistical properties requested (for example `mean`, `std`) any method available on `xarray.Dataset.{op}` can be used. In addition methods prefixed by `diff_` (so the operational would be listed as `diff_{op}`) to compute a statistic based on difference of consecutive time-steps, e.g. `diff_mean` to compute the `mean` of the difference between consecutive timesteps (these are used for normalisating increments). The `dims` attribute defines the dimensions to calculate the statistics over (for example `grid_index` and `time`).
 
 ### The `inputs` section

--- a/example.danra.yaml
+++ b/example.danra.yaml
@@ -20,8 +20,20 @@ output:
         start: 1990-09-03T00:00
         end: 1990-09-06T00:00
         compute_statistics:
-          ops: [mean, std, diff_mean, diff_std]
-          dims: [grid_index, time]
+          MeanStatistic:
+            dims: [grid_index, time]
+          StdStatistic:
+            dims: [grid_index, time]
+          DiffMeanStatistic:
+            dims: [grid_index, time]
+          DiffTimeMeanStatistic:
+            dims: [time]
+          DiffStdStatistic:
+            dims: [grid_index, time]
+          DiurnalDiffMeanStatistic:
+            dims: [grid_index, time]
+          DiurnalDiffStdStatistic:
+            dims: [grid_index, time]
       val:
         start: 1990-09-06T00:00
         end: 1990-09-07T00:00

--- a/example.danra.yaml
+++ b/example.danra.yaml
@@ -21,30 +21,30 @@ output:
         end: 1990-09-06T00:00
         compute_statistics:
           MeanOperator:
-            - name: mean
+            - var_name: mean
               dims: [grid_index, time]
           StdOperator:
-            - name: std
+            - var_name: std
               dims: [grid_index, time]
           DiffMeanOperator:
-            - name: diff_mean
+            - var_name: diff_mean
               dims: [grid_index, time]
-            - name: diff_time_mean
+            - var_name: diff_time_mean
               dims: [time]
           DiffStdOperator:
-            - name: diff_std
+            - var_name: diff_std
               dims: [grid_index, time]
-            - name: diff_time_std
+            - var_name: diff_time_std
               dims: [time]
           DiurnalDiffMeanOperator:
-            - name: diurnal_diff_mean
+            - var_name: diurnal_diff_mean
               dims: [grid_index, time]
-            - name: diurnal_diff_time_mean
+            - var_name: diurnal_diff_time_mean
               dims: [time]
           DiurnalDiffStdOperator:
-            - name: diurnal_diff_std
+            - var_name: diurnal_diff_std
               dims: [grid_index, time]
-            - name: diurnal_diff_time_std
+            - var_name: diurnal_diff_time_std
               dims: [time]
       val:
         start: 1990-09-06T00:00

--- a/example.danra.yaml
+++ b/example.danra.yaml
@@ -20,20 +20,32 @@ output:
         start: 1990-09-03T00:00
         end: 1990-09-06T00:00
         compute_statistics:
-          MeanStatistic:
-            dims: [grid_index, time]
-          StdStatistic:
-            dims: [grid_index, time]
-          DiffMeanStatistic:
-            dims: [grid_index, time]
-          DiffTimeMeanStatistic:
-            dims: [time]
-          DiffStdStatistic:
-            dims: [grid_index, time]
-          DiurnalDiffMeanStatistic:
-            dims: [grid_index, time]
-          DiurnalDiffStdStatistic:
-            dims: [grid_index, time]
+          MeanOperator:
+            - name: mean
+              dims: [grid_index, time]
+          StdOperator:
+            - name: std
+              dims: [grid_index, time]
+          DiffMeanOperator:
+            - name: diff_mean
+              dims: [grid_index, time]
+            - name: diff_time_mean
+              dims: [time]
+          DiffStdOperator:
+            - name: diff_std
+              dims: [grid_index, time]
+            - name: diff_time_std
+              dims: [time]
+          DiurnalDiffMeanOperator:
+            - name: diurnal_diff_mean
+              dims: [grid_index, time]
+            - name: diurnal_diff_time_mean
+              dims: [time]
+          DiurnalDiffStdOperator:
+            - name: diurnal_diff_std
+              dims: [grid_index, time]
+            - name: diurnal_diff_time_std
+              dims: [time]
       val:
         start: 1990-09-06T00:00
         end: 1990-09-07T00:00

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -171,7 +171,7 @@ class Statistic:
         The dimensions to compute the statistics over, e.g. ["time", "grid_index"].
     """
 
-    name: str
+    var_name: str
     dims: List[str]
 
 

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -171,6 +171,7 @@ class Statistic:
         The dimensions to compute the statistics over, e.g. ["time", "grid_index"].
     """
 
+    name: str
     dims: List[str]
 
 
@@ -192,7 +193,7 @@ class Split:
 
     start: str
     end: str
-    compute_statistics: Dict[str, Statistic] = None
+    compute_statistics: Dict[str, List[Statistic]] = None
 
 
 @dataclass

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -157,7 +157,7 @@ class InputDataset:
 
 
 @dataclass
-class Statistics:
+class Statistic:
     """
     Define the statistics to compute for the output dataset, this includes defining
     the the statistics to compute and the dimensions to compute the statistics over.
@@ -171,7 +171,6 @@ class Statistics:
         The dimensions to compute the statistics over, e.g. ["time", "grid_index"].
     """
 
-    ops: List[str]
     dims: List[str]
 
 
@@ -193,7 +192,7 @@ class Split:
 
     start: str
     end: str
-    compute_statistics: Statistics = None
+    compute_statistics: Dict[str, Statistic] = None
 
 
 @dataclass

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -84,11 +84,6 @@ class DimMapping:
         E.g. `{"grid_index": {"method": "stack", "dims": ["x", "y"]}}` will stack the "x" and "y"
         dimensions in the input dataset into a new "grid_index" dimension in the output.
 
-    Attributes:
-        method: The method used for mapping.
-        dims: The dimensions to be mapped.
-        name_format: The format for naming the mapped dimensions.
-
     Attributes
     ----------
     method: str
@@ -265,12 +260,6 @@ class Output:
 @dataclass
 class Config(dataclass_wizard.JSONWizard, dataclass_wizard.YAMLWizard):
     """Configuration for the model.
-
-    Attributes:
-        schema_version: Version of the config file schema.
-        dataset_version: Version of the dataset itself.
-        architecture: Information about the model architecture this dataset is intended for.
-        inputs: Input datasets for the model.
 
     Attributes
     ----------

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -197,7 +197,7 @@ def create_dataset(config: Config):
                 logger.info(f"Computing statistics for split {split_name}")
                 split_stats = calc_stats(
                     ds=ds_split,
-                    statistics_config=split_config.compute_statistics,
+                    statistic_configs=split_config.compute_statistics,
                     splitting_dim=splitting.dim,
                 )
                 for op, op_dataarrays in split_stats.items():
@@ -218,9 +218,9 @@ def create_dataset(config: Config):
     ds.attrs["schema_version"] = config.schema_version
     ds.attrs["dataset_version"] = config.dataset_version
     ds.attrs["created_on"] = datetime.datetime.now().replace(microsecond=0).isoformat()
-    ds.attrs[
-        "created_with"
-    ] = "mllam-data-prep (https://github.com/mllam/mllam-data-prep)"
+    ds.attrs["created_with"] = (
+        "mllam-data-prep (https://github.com/mllam/mllam-data-prep)"
+    )
     ds.attrs["mdp_version"] = f"v{__version__}"
 
     return ds

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -218,9 +218,9 @@ def create_dataset(config: Config):
     ds.attrs["schema_version"] = config.schema_version
     ds.attrs["dataset_version"] = config.dataset_version
     ds.attrs["created_on"] = datetime.datetime.now().replace(microsecond=0).isoformat()
-    ds.attrs["created_with"] = (
-        "mllam-data-prep (https://github.com/mllam/mllam-data-prep)"
-    )
+    ds.attrs[
+        "created_with"
+    ] = "mllam-data-prep (https://github.com/mllam/mllam-data-prep)"
     ds.attrs["mdp_version"] = f"v{__version__}"
 
     return ds

--- a/mllam_data_prep/ops/statistics.py
+++ b/mllam_data_prep/ops/statistics.py
@@ -41,9 +41,9 @@ def calc_stats(
             # of the same operator can be applied)
             for statistic in statistics:
                 operator: StatisticOperator = globals()[stat_name](
-                    ds=ds, splitting_dim=splitting_dim, name=statistic.name
+                    ds=ds, splitting_dim=splitting_dim, var_name=statistic.var_name
                 )
-                stats[statistic.name] = operator.calc_stats(statistic.dims)
+                stats[statistic.var_name] = operator.calc_stats(statistic.dims)
         else:
             raise NotImplementedError(stat_name)
 
@@ -67,7 +67,7 @@ class StatisticOperator(ABC):
 
     ds: xr.Dataset
     splitting_dim: str
-    name: str
+    var_name: str
 
     @abstractmethod
     def calc_stats(self, dims):


### PR DESCRIPTION
Reworked the way we define statistical methods and the way we invoke them from the *.yaml file.

Added new statistical methods to calculate:
- mean and std across time only (no mean/std over grid_index)
- mean and std across diurnal cycles and grid_index
- mean and std across diurnal cycles only

Fixed typos in README. Removed duplicate and obsolete attributes section in docstrings.

The new way to specify compute statistics in the *.yaml file looks like the following:
```yaml
compute_statistics:
    MeanOperator:
      - var_name: mean
        dims: [grid_index, time]
    StdOperator:
      - var_name: std
        dims: [grid_index, time]
    DiffMeanOperator:
      - var_name: diff_mean
        dims: [grid_index, time]
      - var_name: diff_time_mean
        dims: [time]
    ...
```
and follows the structure
```yaml
compute_statistics:
    <name-of-python-class>:
      - var_name: <varible-name1>
        dims: [<dim1>, <dim2>, ...]
      - var_name: <varible-name2>
        dims: [<dim2>, <dim3>, ...]
```
where
- <name-of-python-class> shall be the name of a subclass of `ops.statistics::StatisticOperator` defined in `ops/statistics.py`
- <varible-name*> is a variable name to be used when saving the statistics to the dataset
- the list of dims can vary between <varible-name*> items.