### PR TITLE
add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+## Describe your changes
+
+< Summary of the changes.>
+
+< Please also include relevant motivation and context. >
+
+< List any dependencies that are required for this change. >
+
+## Issue Link
+
+< Link to the relevant issue or task. > (e.g. `closes #00` or `solves #00`)
+
+## Type of change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 📖 Documentation (Addition or improvements to documentation)
+
+## Checklist before requesting a review
+
+- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
+- [ ] I have performed a self-review of my code
+- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
+- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
+- [ ] I have updated the documentation to cover introduced code changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
+- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)
+
+## Checklist for reviewers
+
+Each PR comes with its own improvements and flaws. The reviewer should check the following:
+- [ ] the code is readable
+- [ ] the code is well tested
+- [ ] the code is documented (including return types and parameters)
+- [ ] the code is easy to maintain
+
+## Author checklist after completed review
+
+- [ ] I have added a line to the CHANGELOG describing this change, in a section
+  reflecting type of change (add section where missing):
+  - *added*: when you have added new functionality
+  - *changed*: when default behaviour of the code has been changed
+  - *fixes*: when your contribution fixes a bug
+
+## Checklist for assignee
+
+- [ ] PR is up to date with the base branch
+- [ ] the tests pass
+- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
+- Once the PR is ready to be merged, squash commits and merge the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased](https://github.com/mllam/mllam-data-prep/)
+
+[All changes](https://github.com/mllam/mllam-data-prep/compare/v0.5.0...HEAD)
+
+### Added
+
+- add github PR template to guide development process on github [\#44](https://github.com/mllam/mllam-data-prep/pull/44), @leifdenby
+
 ## [v0.5.0](https://github.com/mllam/mllam-data-prep/releases/tag/v0.5.0)
 
 [All changes](https://github.com/mllam/mllam-data-prep/compare/v0.4.0...v0.5.0)


### PR DESCRIPTION
We currently don't have a PR template. This PR adds this :) The current PR template suggested in this PR is a direct copy of the one from weather-model-graphs: https://github.com/mllam/weather-model-graphs/blob/main/.github/pull_request_template.md

Closes #41 