### PR TITLE
add support for zarr-python 3

### DIFF
--- a/.github/workflows/python-package-pip.yml
+++ b/.github/workflows/python-package-pip.yml
@@ -10,18 +10,20 @@ on:
 
 jobs:
   test:
-    name: Test pip install python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Test pip install python ${{ matrix.python-version }} on ${{ matrix.os }} with zarr ${{ matrix.zarr-version }}
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10"]
+        zarr-version: [">=2,<3", ">2,<=3"]
     steps:
       - uses: actions/checkout@v2
       - name: Install package with pip
         run: |
-          python -m pip install .
+          python -m pip install . "zarr${{ matrix.zarr-version }}"
           python -m pip install pytest
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add github PR template to guide development process on github [\#44](https://github.com/mllam/mllam-data-prep/pull/44), @leifdenby
+- add support for zarr 3.0.0 and above [\#51](https://github.com/mllam/mllam-data-prep/pull/51), @kashif
 
 ## [v0.5.0](https://github.com/mllam/mllam-data-prep/releases/tag/v0.5.0)
 

--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         )
 
         logger.info(
-            f"Setting up dask.distributed.LocalCluster with {n_local_cores} cores and {memory_per_worker/1024/1024:0.0f} MB of memory per worker"
+            f"Setting up dask.distributed.LocalCluster with {n_local_cores} cores and {memory_per_worker / 1024 / 1024:0.0f} MB of memory per worker"
         )
 
         cluster = LocalCluster(

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 from loguru import logger
-from numcodecs import Blosc
+from zarr.codecs import BloscCodec, BloscShuffle
 
 from . import __version__
 from .config import Config, InvalidConfigException
@@ -271,8 +271,8 @@ def create_dataset_zarr(fp_config, fp_zarr: str = None):
 
     # use zstd compression since it has a good balance of speed and compression ratio
     # https://engineering.fb.com/2016/08/31/core-infra/smaller-and-faster-data-compression-with-zstandard/
-    compressor = Blosc(cname="zstd", clevel=1, shuffle=Blosc.BITSHUFFLE)
-    encoding = {v: {"compressor": compressor} for v in ds.data_vars}
+    compressor = BloscCodec(cname="zstd", clevel=3, shuffle=BloscShuffle.bitshuffle)
+    encoding = {v: {"compressors": compressor} for v in ds.data_vars}
 
     ds.to_zarr(fp_zarr, consolidated=True, mode="w", encoding=encoding)
     logger.info(f"Wrote training-ready dataset to {fp_zarr}")

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
+import zarr
 from loguru import logger
-from zarr.codecs import BloscCodec, BloscShuffle
+from packaging.version import Version
 
 from . import __version__
 from .config import Config, InvalidConfigException
@@ -14,6 +15,11 @@ from .ops.loading import load_and_subset_dataset
 from .ops.mapping import map_dims_and_variables
 from .ops.selection import select_by_kwargs
 from .ops.statistics import calc_stats
+
+if Version(zarr.__version__) >= Version("3"):
+    from zarr.codecs import BloscCodec, BloscShuffle
+else:
+    from numcodecs import Blosc
 
 # the `extra` field in the config that was added between v0.2.0 and v0.5.0 is
 # optional, so we can support both v0.2.0 and v0.5.0
@@ -271,8 +277,12 @@ def create_dataset_zarr(fp_config, fp_zarr: str = None):
 
     # use zstd compression since it has a good balance of speed and compression ratio
     # https://engineering.fb.com/2016/08/31/core-infra/smaller-and-faster-data-compression-with-zstandard/
-    compressor = BloscCodec(cname="zstd", clevel=3, shuffle=BloscShuffle.bitshuffle)
-    encoding = {v: {"compressors": compressor} for v in ds.data_vars}
+    if Version(zarr.__version__) >= Version("3"):
+        compressor = BloscCodec(cname="zstd", clevel=3, shuffle=BloscShuffle.bitshuffle)
+        encoding = {v: {"compressors": compressor} for v in ds.data_vars}
+    else:
+        compressor = Blosc(cname="zstd", clevel=1, shuffle=Blosc.BITSHUFFLE)
+        encoding = {v: {"compressor": compressor} for v in ds.data_vars}
 
     ds.to_zarr(fp_zarr, consolidated=True, mode="w", encoding=encoding)
     logger.info(f"Wrote training-ready dataset to {fp_zarr}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     {name = "Emy Alerskans", email = "ea@dmi.dk"},
     {name = "Eleni Briola", email = "elb@dmi.dk"},
     {name = "Joel Oskarsson", email = "joel.oskarsson@liu.se"},
+    {name = "Kashif Rasul", email = "kashif.rasul@gmail.com"},
 ]
 dependencies = [
     "xarray>=2024.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "rich>=13.7.1",
     "dask>=2024.2.1",
     "psutil>=5.7.2",
+    "packaging>=23.1",
 ]
 requires-python = ">=3.9"
 readme = "README.md"


### PR DESCRIPTION
## Describe your changes

Update the zarr compressors API and fixed some warnings for zarr v3.

## Issue Link

was getting the error:

```
/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/group.py:2349: UserWarning: The `compressor` argument is deprecated. Use `compressors` instead.
  compressors = _parse_deprecated_compressor(compressor, compressors)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/mnt/scratch/kashif/mllam-data-prep/mllam_data_prep/__main__.py", line 80, in <module>
    create_dataset_zarr(fp_config=args.config, fp_zarr=args.output)
  File "/mnt/scratch/kashif/mllam-data-prep/mllam_data_prep/create_dataset.py", line 277, in create_dataset_zarr
    ds.to_zarr(fp_zarr, consolidated=True, mode="w", encoding=encoding)
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/xarray/core/dataset.py", line 2622, in to_zarr
    return to_zarr(  # type: ignore[call-overload,misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/xarray/backends/api.py", line 2216, in to_zarr
    dump_to_store(dataset, zstore, writer, encoding=encoding)
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/xarray/backends/api.py", line 1952, in dump_to_store
    store.store(variables, attrs, check_encoding, writer, unlimited_dims=unlimited_dims)
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/xarray/backends/zarr.py", line 1022, in store
    self.set_variables(
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/xarray/backends/zarr.py", line 1194, in set_variables
    zarr_array = self._create_new_array(
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/xarray/backends/zarr.py", line 1089, in _create_new_array
    zarr_array = self.zarr_group.create(
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/group.py", line 2234, in create
    return self.create_array(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/_compat.py", line 43, in inner_f
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/group.py", line 2351, in create_array
    self._sync(
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/sync.py", line 187, in _sync
    return sync(
           ^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/sync.py", line 142, in sync
    raise return_result
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/sync.py", line 98, in _runner
    return await coro
           ^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/group.py", line 1119, in create_array
    return await create_array(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/array.py", line 3919, in create_array
    array_array, array_bytes, bytes_bytes = _parse_chunk_encoding_v3(
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/array.py", line 4120, in _parse_chunk_encoding_v3
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/core/array.py", line 4120, in <genexpr>
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kashif/.venv/pytorch/lib/python3.12/site-packages/zarr/registry.py", line 184, in _parse_bytes_bytes_codec
    raise TypeError(f"Expected a BytesBytesCodec. Got {type(data)} instead.")
TypeError: Expected a BytesBytesCodec. Got <class 'numcodecs.blosc.Blosc'> instead.
```

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
