### PR TITLE
use field default-factory for optional dict fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - correct chunk size estimate [\#59](https://github.com/mllam/mllam-data-prep/pull/59), @ealerskans
 - fix bug arising when variables provided to derived functions are renamed [\#56](https://github.com/mllam/mllam-data-prep/pull/56), @leifdenby
+- ensure config fields defaulting to `None` are typed as `Optional` and fields defaulting to `{}` are given a default-factory so that serialization with default values works correctly [\#63](https://github.com/mllam/mllam-data-prep/pull/63), @leifdenby
 
 ### Maintenance
 

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -74,7 +74,7 @@ class Range:
 
     start: Union[str, int, float]
     end: Union[str, int, float]
-    step: Union[str, int, float] = None
+    step: Optional[Union[str, int, float]] = None
 
 
 @dataclass
@@ -93,7 +93,7 @@ class ValueSelection:
     """
 
     values: Union[List[Union[float, int]], Range]
-    units: str = None
+    units: Optional[str] = None
 
 
 @dataclass
@@ -177,7 +177,7 @@ class DimMapping:
     method: str
     dims: Optional[List[str]] = None
     dim: Optional[str] = None
-    name_format: str = field(default=None)
+    name_format: Optional[str] = field(default=None)
 
 
 @dataclass
@@ -273,7 +273,7 @@ class Split:
 
     start: str
     end: str
-    compute_statistics: Statistics = None
+    compute_statistics: Optional[Statistics] = None
 
 
 @dataclass

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -332,9 +332,9 @@ class Output:
     """
 
     variables: Dict[str, List[str]]
-    coord_ranges: Dict[str, Range] = None
+    coord_ranges: Dict[str, Range] = field(default_factory=dict)
     chunking: Dict[str, int] = field(default_factory=dict)
-    splitting: Splitting = None
+    splitting: Optional[Splitting] = None
 
 
 @dataclass
@@ -371,7 +371,7 @@ class Config(dataclass_wizard.JSONWizard, dataclass_wizard.YAMLWizard):
     inputs: Dict[str, InputDataset]
     schema_version: str
     dataset_version: str
-    extra: Dict[str, Any] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         validate_config(self.inputs)

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -126,7 +126,7 @@ def create_dataset(config: Config):
             f" {', '.join(SUPPORTED_CONFIG_VERSIONS)} are supported by mllam-data-prep "
             f"v{__version__}."
         )
-    if config.schema_version == "v0.2.0" and config.extra is not None:
+    if config.schema_version == "v0.2.0" and config.extra != {}:
         raise ValueError(
             "Config schema version v0.2.0 does not support the `extra` field. Please "
             "update the schema version used in your config to v0.5.0."

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -126,7 +126,7 @@ def create_dataset(config: Config):
             f" {', '.join(SUPPORTED_CONFIG_VERSIONS)} are supported by mllam-data-prep "
             f"v{__version__}."
         )
-    if config.schema_version == "v0.2.0" and config.extra != {}:
+    if config.schema_version == "v0.2.0" and config.extra:
         raise ValueError(
             "Config schema version v0.2.0 does not support the `extra` field. Please "
             "update the schema version used in your config to v0.5.0."


### PR DESCRIPTION
## Describe your changes

This PR fixes a bug with the config specification for fields that are of `dict` type but are optional. I had previously thought it was ok to set these to `None` by default, but that doesn't work because when constructing the nested dataclasses the initialisation tries to iterate over the `.items()` in these optional fields. Since these fields were defaulting to `None` this would raise an `AttributeError`. Instead for fields of `dict` type where these fields are optional one must use a `dataclass.field(default_factory={})` constructor so that an empty `dict` is created when intialising the dataclass object.

I think @mafdmi noticed this earlier and has already fixed some of these issues, but I spotted a few more just now when working on the config serialisation feature #46.

No dependencies change

## Issue Link

No related issue

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [ ] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
