### PR TITLE
Enabling storing config in produced dataset and option to overwrite on config change

### DIFF
--- a/mllam_data_prep/__main__.py
+++ b/mllam_data_prep/__main__.py
@@ -39,6 +39,12 @@ if __name__ == "__main__":
         type=float,
         default=0.9,
     )
+    parser.add_argument(
+        "--overwrite",
+        help="Overwrite existing zarr file if it exists",
+        choices=["always", "never", "on_config_change"],
+        default="always",
+    )
     args = parser.parse_args()
 
     if args.show_progress:
@@ -77,4 +83,6 @@ if __name__ == "__main__":
         # print the dashboard link
         logger.info(f"Dashboard link: {cluster.dashboard_link}")
 
-    create_dataset_zarr(fp_config=args.config, fp_zarr=args.output)
+    create_dataset_zarr(
+        fp_config=args.config, fp_zarr=args.output, overwrite=args.overwrite
+    )

--- a/mllam_data_prep/config.py
+++ b/mllam_data_prep/config.py
@@ -332,9 +332,9 @@ class Output:
     """
 
     variables: Dict[str, List[str]]
-    coord_ranges: Dict[str, Range] = None
+    coord_ranges: Dict[str, Range] = field(default_factory=dict)
     chunking: Dict[str, int] = field(default_factory=dict)
-    splitting: Splitting = None
+    splitting: Optional[Splitting] = None
 
 
 @dataclass
@@ -371,7 +371,7 @@ class Config(dataclass_wizard.JSONWizard, dataclass_wizard.YAMLWizard):
     inputs: Dict[str, InputDataset]
     schema_version: str
     dataset_version: str
-    extra: Dict[str, Any] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         validate_config(self.inputs)

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -126,7 +126,7 @@ def create_dataset(config: Config):
             f" {', '.join(SUPPORTED_CONFIG_VERSIONS)} are supported by mllam-data-prep "
             f"v{__version__}."
         )
-    if config.schema_version == "v0.2.0" and config.extra is not None:
+    if config.schema_version == "v0.2.0" and config.extra != {}:
         raise ValueError(
             "Config schema version v0.2.0 does not support the `extra` field. Please "
             "update the schema version used in your config to v0.5.0."

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ed345b0df8664a5ab1aadb77d5c4218ef15f135ddacd674f0d029e5a39f9654d"
+content_hash = "sha256:b6b664c0870d66936516c282c038c66dbd6f579cedeef4276b6ffdfdea2b0a14"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -302,6 +302,20 @@ marker = "python_version > \"3.6\""
 files = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
+name = "deepdiff"
+version = "8.2.0"
+requires_python = ">=3.8"
+summary = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
+groups = ["default"]
+dependencies = [
+    "orderly-set<6,>=5.3.0",
+]
+files = [
+    {file = "deepdiff-8.2.0-py3-none-any.whl", hash = "sha256:5091f2cdfd372b1b9f6bfd8065ba323ae31118dc4e42594371b38c8bea3fd0a4"},
+    {file = "deepdiff-8.2.0.tar.gz", hash = "sha256:6ec78f65031485735545ffbe7a61e716c3c2d12ca6416886d5e9291fc76c46c3"},
 ]
 
 [[package]]
@@ -762,6 +776,17 @@ files = [
     {file = "numpy-2.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38ecb5b0582cd125f67a629072fed6f83562d9dd04d7e03256c9829bdec027ad"},
     {file = "numpy-2.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cef04d068f5fb0518a77857953193b6bb94809a806bd0a14983a8f12ada060c9"},
     {file = "numpy-2.0.0.tar.gz", hash = "sha256:cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864"},
+]
+
+[[package]]
+name = "orderly-set"
+version = "5.3.0"
+requires_python = ">=3.8"
+summary = "Orderly set"
+groups = ["default"]
+files = [
+    {file = "orderly_set-5.3.0-py3-none-any.whl", hash = "sha256:c2c0bfe604f5d3d9b24e8262a06feb612594f37aa3845650548befd7772945d1"},
+    {file = "orderly_set-5.3.0.tar.gz", hash = "sha256:80b3d8fdd3d39004d9aad389eaa0eab02c71f0a0511ba3a6d54a935a6c6a0acc"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "dask>=2024.2.1",
     "psutil>=5.7.2",
     "packaging>=23.1",
+    "deepdiff>=8.2.0",
 ]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/tests/test_existing_output.py
+++ b/tests/test_existing_output.py
@@ -1,0 +1,104 @@
+from copy import deepcopy
+from unittest.mock import patch
+
+import pytest
+import xarray as xr
+
+import mllam_data_prep.config as mdp_config
+from mllam_data_prep.create_dataset import (
+    UnsupportedMllamDataPrepVersion,
+    handle_existing_dataset,
+)
+
+
+@pytest.fixture
+def mock_config():
+    return mdp_config.Config(
+        schema_version="v0.6.0",
+        dataset_version="1.0.0",
+        inputs={},
+        output=mdp_config.Output(variables={}),
+    )
+
+
+@pytest.fixture
+def mock_zarr_path(tmp_path):
+    return tmp_path / "test.zarr"
+
+
+def test_handle_existing_dataset_always_overwrite(mock_config, mock_zarr_path):
+    mock_zarr_path.mkdir()
+    with patch("shutil.rmtree") as mock_rmtree:
+        handle_existing_dataset(
+            config=mock_config, fp_zarr=str(mock_zarr_path), overwrite="always"
+        )
+        mock_rmtree.assert_called_once_with(str(mock_zarr_path))
+
+
+def test_handle_existing_dataset_never_overwrite(mock_config, mock_zarr_path):
+    mock_zarr_path.mkdir()
+    with patch("shutil.rmtree") as mock_rmtree:
+        handle_existing_dataset(
+            config=mock_config, fp_zarr=str(mock_zarr_path), overwrite="never"
+        )
+        mock_rmtree.assert_not_called()
+
+
+def test_handle_existing_dataset_on_config_change_same_config(
+    mock_config, mock_zarr_path
+):
+    """
+    Test that when the existing dataset has the same config as the current config, the zarr dataset is not deleted.
+    """
+    mock_zarr_path.mkdir()
+    ds = xr.Dataset(
+        attrs={"mdp_version": "0.6.0", "creation_config": mock_config.to_yaml()}
+    )
+    ds.to_zarr(str(mock_zarr_path))
+    with patch("shutil.rmtree") as mock_rmtree:
+        handle_existing_dataset(
+            config=mock_config,
+            fp_zarr=str(mock_zarr_path),
+            overwrite="on_config_change",
+        )
+        mock_rmtree.assert_not_called()
+
+
+def test_handle_existing_dataset_on_config_change_different_config(
+    mock_config, mock_zarr_path
+):
+    """
+    Test that when the existing dataset has a different config than the current config, the zarr dataset is deleted.
+    """
+    mock_zarr_path.mkdir()
+    different_config = deepcopy(mock_config)
+    different_config.dataset_version = "2.0.0"
+    ds = xr.Dataset(
+        attrs={"mdp_version": "0.6.0", "creation_config": different_config.to_yaml()}
+    )
+    ds.to_zarr(str(mock_zarr_path))
+    with patch("shutil.rmtree") as mock_rmtree:
+        handle_existing_dataset(
+            config=mock_config,
+            fp_zarr=str(mock_zarr_path),
+            overwrite="on_config_change",
+        )
+        mock_rmtree.assert_called_once_with(str(mock_zarr_path))
+
+
+def test_handle_existing_dataset_older_version(mock_config, mock_zarr_path):
+    """
+    Test that when the existing dataset was created with an older version of mllam-data-prep, an exception is raised.
+    Since for older versions we do not have the creation_config attribute, we cannot compare the configs.
+    """
+    mock_zarr_path.mkdir()
+    ds = xr.Dataset(attrs={"mdp_version": "0.5.0"})
+    ds.to_zarr(str(mock_zarr_path))
+    with pytest.raises(
+        UnsupportedMllamDataPrepVersion, match="older version of mllam-data-prep"
+    ):
+        handle_existing_dataset(
+            config=mock_config,
+            fp_zarr=str(mock_zarr_path),
+            overwrite="on_config_change",
+        )


### PR DESCRIPTION
## Describe your changes

Currently, if dataset exists in the path that `mllam-data-prep` is about to write to then `mllam-data-prep` will always overwrite (delete the dataset and write a new one). This PR introduces the option to only overwrite if the config has changed. This is made possible by serialising the config that a dataset was created from as a yaml-formatted string added as an attribute called `creation_config` to the dataset output by `mllam-data-prep`. The motivation for this feature is to avoid the recreation of datasets unless absolutely needed.

This adds a new cli arg called `--overwrite [always,never,on_config_change]` which defaults to `always` so that the default behaviour isn't changed.

I hope that this feature will be included in `v0.6.0` of `mllam-data-prep` and so I have made usage of the option `on_config_change` contingent on the dataset having been made by at minimum `v0.6.0` (lower versions will not have the config stored in the dataset). For datasets made with older versions of `mllam-data-prep` the cli will raise an exception saying that `on_config_change` cannot be used because the dataset was created with an older version of `mllam-data-prep`

I've added the [deepdiff](https://github.com/seperman/deepdiff) package so I can print the changes to the config when the dataset is being overwritten because the config had changed and the user provided `overwrite='on_config_change'`.

NB: https://github.com/mllam/mllam-data-prep/pull/63 should be merged first because I noticed some issues with optional `dict` fields in the config dataclasses when writing the tests.

## Issue Link

https://github.com/mllam/mllam-data-prep/issues/46
https://github.com/mllam/neural-lam/issues/82

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
