### PR TITLE
Update the config validation with a check for selection of variables by coord values not yet supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The `inputs` section defines the source datasets to extract data from. Each sour
 
 - `path`: the path to the source dataset. This can be a local path or a URL to e.g. a zarr dataset or netCDF file, anything that can be read by `xarray.open_dataset(...)`.
 - `dims`: the dimensions that the source dataset is expected to have. This is used to check that the source dataset has the expected dimensions and also makes it clearer in the config file what the dimensions of the source dataset are.
-- `variables`: selects which variables to extract from the source dataset. This may either be a list of variable names, or a dictionary where each key is the variable name and the value defines a dictionary of coordinates to do selection on. When doing selection you may also optionally define the units of the variable to check that the units of the variable match the units of the variable in the model architecture.
+- `variables`: selects which variables to extract from the source dataset. This may either be a list of variable names, or a dictionary where each key is the variable name and the value defines a dictionary of coordinates to do selection on. When doing selection you may also optionally define the units of the variable to check that the units of the variable match the units of the variable in the model architecture. See also the 'Selection of variables by coordinates' section for more details on the type of selections allowed.
 - `target_output_variable`: the variable in the model architecture that the source dataset should be mapped to.
 - `dim_mapping`: defines how the dimensions of the source dataset should be mapped to the dimensions of the model architecture. This is done by defining a method to apply to each dimension. The methods are:
   - `rename`: simply rename the dimension to the new name
@@ -359,6 +359,97 @@ The `inputs` section defines the source datasets to extract data from. Each sour
 - `derived_variables`: defines the variables to be derived from the variables available in the source dataset. This should be a dictionary where each key is the name of the variable to be derived and the value defines a dictionary with the following additional information. See also the 'Derived Variables' section for more details.
   - `function`: the function used to derive a variable. This should be a string with the full namespace of the function, e.g. `mllam_data_prep.ops.derived_variables.physical_field.calculate_toa_radiation`.
   - `kwargs`: arguments to `function`. This is a dictionary where each key is the named argument to `function` and each value is the input to the function. Here we distinguish between values to be extracted/selected from the input dataset and values supplied by the users themselves. Arguments with values to be extracted from the input dataset need to be prefixed with "ds_input." to distinguish them from other arguments. See the 'Derived Variables' section for more details.
+
+#### Selection of variables by coordinates
+When selecting variables to extract from the source dataset it is possible to also specify a selection on coordinates. Currently it is only allowed to, within one input dataset, specify the variables to extract with a selection on coordinates **if the coordinates are for the same levels**, as illustrated in the example config [example.danra.yaml](example.danra.yaml), and also reproduced below, for the selection of `u` and `v` at 100 m height.
+```yaml
+    variables:
+      u:
+        altitude:
+          values: [100,]
+          units: m
+      v:
+        altitude:
+          values: [100, ]
+          units: m
+```
+
+Currently, support for the selection of variables from different coordinate levels within one input dataset is not implemented. This means that the following selections are currently not allowed within the same input dataset
+```yaml
+    variables:
+      z:
+        altitude:
+          values: [100, 50]
+          units: m
+      t:
+        altitude:
+          values: [100, ]
+          units: m
+```
+and
+```yaml
+    variables:
+      z:
+        altitude:
+          values: [50]
+          units: m
+      t:
+        altitude:
+          values: [100, ]
+          units: m
+```
+
+Instead you need to split the selection across multiple input datasets. For the first example, you need have two separate input datasets, where you could split it in two separate ways. You could either do
+```yaml
+inputs:
+  danra_height_levels_100m:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/height_levels.zarr
+    dims: [time, x, y, altitude]
+    variables:
+      z:
+        altitude:
+          values: [100,]
+          units: m
+      t:
+        altitude:
+          values: [100, ]
+          units: m
+    ...
+
+  danra_height_levels_50m:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/height_levels.zarr
+    dims: [time, x, y, altitude]
+    variables:
+      z:
+        altitude:
+          values: [50,]
+          units: m
+    ...
+```
+or
+```yaml
+inputs:
+  danra_height_levels_z:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/height_levels.zarr
+    dims: [time, x, y, altitude]
+    variables:
+      z:
+        altitude:
+          values: [100, 50,]
+          units: m
+    ...
+
+  danra_height_levels_t:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/height_levels.zarr
+    dims: [time, x, y, altitude]
+    variables:
+      t:
+        altitude:
+          values: [100,]
+          units: m
+    ...
+```
+Similarly, you need to split the selection in the second example across two separate input datasets.
 
 #### Derived Variables
 Variables that are not part of the source dataset but can be derived from variables in the source dataset can also be included. They should be defined in their own section, called `derived_variables` as illustrated in the example config above and in the example config file [example.danra.yaml](example.danra.yaml).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,8 @@
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
 import pytest
 from dataclass_wizard.errors import MissingFields, UnknownJSONKey
 
@@ -119,3 +124,157 @@ def test_get_config_nested():
         assert input_config.target_output_variable is not None
         with pytest.raises(AttributeError):
             input_config.foobarfield
+
+
+INVALID_MISSING_VARIABLES_YAML = """
+inputs:
+  danra_height_levels:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/single_levels.zarr
+    dims: [time, x, y]
+    dim_mapping:
+      time:
+        method: rename
+        dim: time
+      state_feature:
+        method: stack_variables_by_var_name
+        name_format: "{var_name}"
+      grid_index:
+        method: stack
+        dims: [x, y]
+    target_output_variable: state
+"""
+
+INVALID_OVERLAPPING_VARIABLE_NAMES_YAML = """
+inputs:
+  danra_height_levels:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/single_levels.zarr
+    dims: [time, x, y]
+    variables:
+      - swavr0m
+    derived_variables:
+      swavr0m:
+        kwargs:
+          time: ds_input.time
+          lat: ds_input.lat
+          lon: ds_input.lon
+        function: mllam_data_prep.ops.derive_variable.physical_field.calculate_toa_radiation
+    dim_mapping:
+      time:
+        method: rename
+        dim: time
+      state_feature:
+        method: stack_variables_by_var_name
+        name_format: "{var_name}"
+      grid_index:
+        method: stack
+        dims: [x, y]
+    target_output_variable: state
+"""
+
+INVALID_INPUTS_COORDS_SELECTION_YAML = """
+inputs:
+  danra_height_levels:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/height_levels.zarr
+    dims: [time, x, y, altitude]
+    variables:
+      u:
+        altitude:
+          values: [100, ]
+          units: m
+      v:
+        altitude:
+          values: [50, ]
+          units: m
+    dim_mapping:
+      time:
+        method: rename
+        dim: time
+      state_feature:
+        method: stack_variables_by_var_name
+        dims: [altitude]
+        name_format: "{var_name}{altitude}m"
+      grid_index:
+        method: stack
+        dims: [x, y]
+    target_output_variable: state
+"""
+
+
+def modify_example_config_inputs_section_yaml(new_inputs_section):
+    """
+    Get the example config file as a yaml string and replace the
+    `inputs` section with a new inputs section before
+
+    Parameters
+    ----------
+    new_inputs_section: str
+        String with a new inputs section
+    Returns
+    -------
+    modified_yaml: str
+        Modified config yaml with the new inputs section replacing
+        the old one in the example config
+    """
+    # Copy the config file to a temporary directory before reading it
+    fp_example = "example.danra.yaml"
+    tmpdir = tempfile.TemporaryDirectory()
+    fp_config_copy = Path(tmpdir.name) / fp_example
+    shutil.copy(fp_example, fp_config_copy)
+
+    # Read the example config file as text to preserve the order
+    base_config_yaml = Path(fp_config_copy).read_text()
+
+    # Use regex to replace the entire "inputs:" block
+    if new_inputs_section:
+        modified_yaml = re.sub(
+            r"inputs:\n((?:\s{2,}.*\n)*)",  # Matches "inputs:" and all indented content
+            new_inputs_section,
+            base_config_yaml,
+        )
+    else:
+        modified_yaml = base_config_yaml
+
+    return modified_yaml
+
+
+@pytest.mark.parametrize(
+    "invalid_inputs_section, expected_exception, expected_message",
+    [
+        (
+            # Invalid inputs section with missing `variables` and/or `derived_variables`
+            INVALID_MISSING_VARIABLES_YAML,  # invalid config yaml example
+            mdp.InvalidConfigException,  # expected exception
+            "Missing `variables` and/or `derived_variables`",  # expected error message from
+        ),
+        (
+            # Invalid inputs section with overlapping variable names between `variables`
+            # and `derived_variables`
+            INVALID_OVERLAPPING_VARIABLE_NAMES_YAML,
+            mdp.InvalidConfigException,
+            "Overlapping variable names in `variables` and `derived_variables`",
+        ),
+        (
+            # Invalid inputs section selection of variables from different coords levels,
+            # which is currently not implemented
+            INVALID_INPUTS_COORDS_SELECTION_YAML,
+            NotImplementedError,
+            "Selection of variables from different coord levels is currently not supported",
+        ),
+    ],
+)
+def test_config_validation_of_inputs_section(
+    invalid_inputs_section, expected_exception, expected_message
+):
+    """
+    Test that `validate_config` raises the coerrect exceptions when an inputs dataset
+    1. is missing `variables` and/or `derived_variables`
+    2. has overlapping variable names between `variables` and `derived_variables`
+    3. includes a selection of variables from different coord levels, since this is not yet implemented
+    """
+    # Modify the example config
+    invalid_config_yaml = modify_example_config_inputs_section_yaml(
+        invalid_inputs_section
+    )
+
+    with pytest.raises(expected_exception, match=expected_message):
+        mdp.Config.from_yaml(invalid_config_yaml)


### PR DESCRIPTION
## Describe your changes

The current implementation of selection of variables by coordinate values does not, within one input dataset, support the selection of variables from different coordinate levels. E.g. the following selection
```yaml
    variables:
      u:
        altitude:
          values: [100, 50, ]
          units: m
      v:
        altitude:
          values: [100, 75, ]
          units: m
      t:
        altitude:
          values: [30, ]
          units: m
```
would currently add `u100m`, `u50m`, `v100m`, `v50m`, `t100m`, `t50m` to the output dataset. So it results in missing variables ( `v75m` and `t30m`) but also adds extra variables (`v50m`, `t100m` and `t50m`), which all are just nans. Such a selection is something we would like to support but the current implementation does not.

Implementing the support of such a selection would require changes to the way that the selected (and derived) variables are collected (currently in one dataset before merging and dimension mapping). Until such a time, this PR adds a `NotImplementedError` exception in `validate_config` if one tries to do a selection of variables on different coordinate values within one input dataset. It also adds a section to the README with an explanation of the allowed selections and how to do the selection of variables on different coordinate values.

I have also added tests to check that the exceptions raised in `validate_config` are correctly caught.

No change in dependencies needed for this change.

## Issue Link

Addresses #61.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
