### PR TITLE
Bugfix for input order effecting coord ranges slicing in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased](https://github.com/mllam/mllam-data-prep/compare/v0.6.1...HEAD)
+
+### Fixes
+- fix bug where coordinate selection of an unshared dimension isn't applied to subsequent ouput variables when an output variable without this dimension is processed before the others [\#87](https://github.com/mllam/mllam-data-prep/pull/87) @zweihuehner
+
 ## [v0.6.1](https://github.com/mllam/mllam-data-prep/release/tag/v0.6.1)
 
 [All changes](https://github.com/mllam/mllam-data-prep/compare/v0.6.1...v0.6.0)
@@ -13,7 +18,6 @@ This release contains bugfixes to update tests to use newer version of pre-commi
 
 ### Fixes
 - use old union typing notation compatible with all required python versions [\#77](https://github.com/mllam/mllam-data-prep/pull/77) @SimonKamuk
-- fix bug that would overwrite the output_coord_ranges dictionary if feature order in datastore.yaml is incorrect [\#87](https://github.com/mllam/mllam-data-prep/pull/87) @zweihuehner
 
 ### Maintenance
 - update pre-commit action to v3.0.1 [\#77](https://github.com/mllam/mllam-data-prep/pull/77) @SimonKamuk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This release contains bugfixes to update tests to use newer version of pre-commi
 
 ### Fixes
 - use old union typing notation compatible with all required python versions [\#77](https://github.com/mllam/mllam-data-prep/pull/77) @SimonKamuk
+- fix bug that would overwrite the output_coord_ranges dictionary if feature order in datastore.yaml is incorrect [\#87](https://github.com/mllam/mllam-data-prep/pull/87) @zweihuehner
 
 ### Maintenance
 - update pre-commit action to v3.0.1 [\#77](https://github.com/mllam/mllam-data-prep/pull/77) @SimonKamuk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased](https://github.com/mllam/mllam-data-prep/compare/v0.6.1...HEAD)
+## [unreleased](https://github.com/mllam/mllam-data-prep/compare/v0.7.0...HEAD)
 
 ### Fixes
-- fix bug where coordinate selection of an unshared dimension isn't applied to subsequent ouput variables when an output variable without this dimension is processed before the others [\#87](https://github.com/mllam/mllam-data-prep/pull/87) @zweihuehner
+- fix bug where coordinate selection of an unshared dimension isn't applied to subsequent ouput variables when an output variable without this dimension is processed before the others [\#90](https://github.com/mllam/mllam-data-prep/pull/90) @zweihuehner & @leifdenby
 
 ## [v0.7.0](https://github.com/mllam/mllam-data-prep/release/tag/v0.7.0)
 

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -236,10 +236,10 @@ def create_dataset(config: Config):
 
         # only need to do selection for the coordinates that the input dataset actually has
         if output_coord_ranges is not None:
-            # Use a temporary dict to apply selection on coordinate ranges to avoid 
-		    # modifying the original ranges given in the config. This is needed because 
-		    # static features, for example, do not have a time dimension. Hence, the time
-		    # based selection returns an empty dictionary, which should not overwrite the 
+            # Use a temporary dict to apply selection on coordinate ranges to avoid
+            # modifying the original ranges given in the config. This is needed because
+            # static features, for example, do not have a time dimension. Hence, the time
+            # based selection returns an empty dictionary, which should not overwrite the
             # selection for the other variables.
             output_coord_ranges_tmp = {
                 k: w for k, w in output_coord_ranges.items() if k in output_dims

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -236,8 +236,11 @@ def create_dataset(config: Config):
 
         # only need to do selection for the coordinates that the input dataset actually has
         if output_coord_ranges is not None:
-            # Use a temporary dict to avoid modifying the original ranges.
-            # Static features have no time dimension, so they would return an empty dict.
+            # Use a temporary dict to apply selection on coordinate ranges to avoid 
+		    # modifying the original ranges given in the config. This is needed because 
+		    # static features, for example, do not have a time dimension. Hence, the time
+		    # based selection returns an empty dictionary, which should not overwrite the 
+            # selection for the other variables.
             output_coord_ranges_tmp = {
                 k: w for k, w in output_coord_ranges.items() if k in output_dims
             }

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -236,10 +236,12 @@ def create_dataset(config: Config):
 
         # only need to do selection for the coordinates that the input dataset actually has
         if output_coord_ranges is not None:
-            output_coord_ranges = {
+            # Use a temporary dict to avoid modifying the original ranges.
+            # Static features have no time dimension, so they would return an empty dict.
+            output_coord_ranges_tmp = {
                 k: w for k, w in output_coord_ranges.items() if k in output_dims
             }
-            da_target = select_by_kwargs(da_target, **output_coord_ranges)
+            da_target = select_by_kwargs(da_target, **output_coord_ranges_tmp)
 
         dataarrays_by_target[target_output_var].append(da_target)
 

--- a/mllam_data_prep/create_dataset.py
+++ b/mllam_data_prep/create_dataset.py
@@ -105,10 +105,17 @@ def _merge_dataarrays_by_target(dataarrays_by_target):
         ds = xr.merge(dataarrays, join="exact")
     except ValueError as ex:
         if ex.args[0].startswith("cannot align objects with join='exact'"):
+
+            def _summarize(da):
+                dims = ", ".join([f"{k}: {v}" for k, v in da.sizes.items()])
+                return f"{da.name} ({dims})\n{da.coords}"
+
+            coord_summaries = "\n".join([_summarize(da) for da in dataarrays])
             raise InvalidConfigException(
-                f"Couldn't merge together the dataarrays for all targets ({', '.join(dataarrays_by_target.keys())})"
-                f" This is likely because the dataarrays have different dimensions or coordinates."
-                " Maybe you need to give the 'feature' dimension a unique name for each target variable?"
+                f"Couldn't merge together the dataarrays for all targets ({', '.join(dataarrays_by_target.keys())}). "
+                "This is likely because the dataarrays have different dimensions or coordinates. "
+                f"Dataarray coords:\n{coord_summaries}"
+                "Maybe you need to give the 'feature' dimension a unique name for each target variable?"
             ) from ex
         else:
             raise ex

--- a/tests/test_output_coord_ranges_slicing.py
+++ b/tests/test_output_coord_ranges_slicing.py
@@ -1,0 +1,124 @@
+import itertools
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import mllam_data_prep as mdp
+from mllam_data_prep.config import DimMapping, InputDataset, Output, Range
+
+
+def _write_zarr(ds: xr.Dataset, path):
+    ds.to_zarr(path, mode="w")
+
+
+@pytest.mark.parametrize(
+    "input_order",
+    list(itertools.permutations(["state", "static", "forcing"])),
+)
+def test_output_coord_ranges_not_dropped_between_inputs(tmp_path, input_order):
+    """
+    Ensure output coord range slicing is applied per-input without being
+    affected by the order of inputs. This guards against mutating the shared
+    output_coord_ranges dict when an input lacks a dimension (e.g. `static`
+    without `time`), which would otherwise remove slicing for later inputs.
+
+    See https://github.com/mllam/mllam-data-prep/issues/81 for bug report.
+    """
+    time = pd.date_range("2000-01-01", "2000-01-05", freq="1D")
+    x = np.arange(2)
+
+    state_ds = xr.Dataset(
+        {"s": (("time", "x"), np.zeros((len(time), len(x))))},
+        coords={"time": time, "x": x},
+    )
+    forcing_ds = xr.Dataset(
+        {"f": (("time", "x"), np.ones((len(time), len(x))))},
+        coords={"time": time, "x": x},
+    )
+    static_ds = xr.Dataset(
+        {"static_feature": (("x",), np.array([10.0, 20.0]))},
+        coords={"x": x},
+    )
+
+    state_path = tmp_path / "state.zarr"
+    forcing_path = tmp_path / "forcing.zarr"
+    static_path = tmp_path / "static.zarr"
+
+    _write_zarr(state_ds, state_path)
+    _write_zarr(forcing_ds, forcing_path)
+    _write_zarr(static_ds, static_path)
+
+    inputs_by_name = {
+        "state": InputDataset(
+            path=str(state_path),
+            dims=["time", "x"],
+            variables=["s"],
+            target_output_variable="state",
+            dim_mapping={
+                "time": DimMapping(method="rename", dim="time"),
+                "grid_index": DimMapping(method="stack", dims=["x"]),
+                "state_feature": DimMapping(
+                    method="stack_variables_by_var_name",
+                    name_format="{var_name}",
+                ),
+            },
+        ),
+        "static": InputDataset(
+            path=str(static_path),
+            dims=["x"],
+            variables=["static_feature"],
+            target_output_variable="static",
+            dim_mapping={
+                "grid_index": DimMapping(method="stack", dims=["x"]),
+                "static_feature": DimMapping(
+                    method="stack_variables_by_var_name",
+                    name_format="{var_name}",
+                ),
+            },
+        ),
+        "forcing": InputDataset(
+            path=str(forcing_path),
+            dims=["time", "x"],
+            variables=["f"],
+            target_output_variable="forcing",
+            dim_mapping={
+                "time": DimMapping(method="rename", dim="time"),
+                "grid_index": DimMapping(method="stack", dims=["x"]),
+                "forcing_feature": DimMapping(
+                    method="stack_variables_by_var_name",
+                    name_format="{var_name}",
+                ),
+            },
+        ),
+    }
+
+    ordered_inputs = {name: inputs_by_name[name] for name in input_order}
+
+    config = mdp.Config(
+        schema_version="v0.6.0",
+        dataset_version="v0.0.0",
+        output=Output(
+            variables={
+                "state": ["time", "grid_index", "state_feature"],
+                "forcing": ["time", "grid_index", "forcing_feature"],
+                "static": ["grid_index", "static_feature"],
+            },
+            coord_ranges={
+                "time": Range(
+                    start="2000-01-01T00:00",
+                    end="2000-01-03T00:00",
+                    step="PT24H",
+                )
+            },
+        ),
+        inputs=ordered_inputs,
+    )
+
+    ds = mdp.create_dataset(config=config)
+
+    expected_len = 3
+    assert ds["state"].sizes["time"] == expected_len
+    assert ds["forcing"].sizes["time"] == expected_len
+    assert "time" not in ds["static"].dims


### PR DESCRIPTION
## Describe your changes

As reported on #81 there is currently a bug in `mllam-data-prep` where the order of the inputs affects how the `coord_ranges` selection on the output is applied. This is because the variable holding the coordinate ranges to slice over was being mutated when looping over the output variables.

This was also worked on by @zweihuehner in https://github.com/mllam/mllam-data-prep/pull/87, but something went wrong in the most recent commit there :) I also add a test in this PR to expose the bug to ensure it has been fully fixed.

No change in dependencies needed for this fix

## Issue Link

solves #81

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
