### PR TITLE
Add CLI entrypoint test and mark slow tests #23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,8 @@ dev = [
 ]
 [project.scripts]
 mllam_data_prep = "mllam_data_prep:cli.call"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests requiring network access or AWS credentials (deselect with '-m \"not slow\"')",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,3 +12,14 @@ def test_call(args):
         args.extend(["--output", tmpdir])
         call(args)
         _ = xr.open_zarr(tmpdir)
+
+
+def test_cli_entrypoint_help():
+    """Test the actual installed CLI entry point works as a subprocess."""
+    import subprocess
+    result = subprocess.run(
+        ["mllam_data_prep", "--help"],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "config" in result.stdout.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 
 import pytest
@@ -6,6 +7,7 @@ import xarray as xr
 from mllam_data_prep.cli import call
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("args", [["example.danra.yaml"]])
 def test_call(args):
     with tempfile.TemporaryDirectory(suffix=".zarr") as tmpdir:
@@ -16,7 +18,6 @@ def test_call(args):
 
 def test_cli_entrypoint_help():
     """Test the actual installed CLI entry point works as a subprocess."""
-    import subprocess
     result = subprocess.run(
         ["mllam_data_prep", "--help"],
         capture_output=True, text=True


### PR DESCRIPTION
## Describe your changes

Added a test for the actual installed CLI entry point by running it as a subprocess with `--help`. This catches import/dependency errors (like a missing `psutil` dependency) that would not be caught by calling the Python function directly.

Marked the existing `test_call` as `@pytest.mark.slow` since it requires network access and AWS credentials to run. Registered the `slow` mark in `pyproject.toml` to avoid pytest warnings about unknown marks.

## Issue Link

Closes #23

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📖 Documentation

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form
- [ ] I have requested a reviewer and an assignee

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change